### PR TITLE
Update ANGLE supported Minecraft versions tooltip

### DIFF
--- a/Natives/resources/en.lproj/Localizable.strings
+++ b/Natives/resources/en.lproj/Localizable.strings
@@ -182,7 +182,7 @@
 
 "preference.title.renderer.debug.auto" = "Auto: gl4es or ANGLE";
 "preference.title.renderer.debug.gl4es" = "holy gl4es - exports OpenGL 2.1";
-"preference.title.renderer.debug.angle" = "ANGLE (1.17+) - exports OpenGL 3.2 (Core Profile, limited)";
+"preference.title.renderer.debug.angle" = "ANGLE (1.17-1.21.5) - exports OpenGL 3.2 (Core Profile, limited)";
 "preference.title.renderer.debug.mg" = "MobileGlues (1.17+) - exports OpenGL 4.0, EXPERIMENTAL";
 "preference.title.renderer.debug.zink" = "Zink (Mesa 21.0) - exports OpenGL 4.1";
 


### PR DESCRIPTION
ANGLE cannot run 1.21.6 and above. This should be reflected here.