### PR TITLE
Fix black screen on iOS 26+

### DIFF
--- a/Natives/dyld_bypass_validation.m
+++ b/Natives/dyld_bypass_validation.m
@@ -228,23 +228,21 @@ void init_bypassDyldLibValidation() {
 
     NSDebugLog(@"[DyldLVBypass] init");
     
-    switch ((int)DeviceGetJITFlags(YES)) {
-        case JIT_FLAG_FORCE_MIRRORED | JIT_FLAG_HAS_TXM:
+    if (@available(iOS 26.0, *)) {
+        if (DeviceHasJITFlags(JIT_FLAG_FORCE_MIRRORED | JIT_FLAG_HAS_TXM)) {
             NSDebugLog(@"[DyldLVBypass] Using redirectFunctionMirrored");
             redirectFunction = redirectFunctionMirrored;
-            break;
-        case JIT_FLAG_FORCE_MIRRORED:
-            // Special special case for non-TXM iOS 26+
-            // We can JIT without script, but we cannot modify existing code in dsc without it.
-            // Therefore, we choose a hook method that avoids patching code in dsc completely, using hardware breakpoint.
-            // The function only stashes the original function pointers, and the breakpoint handler will redirect to our hook
+        } else if (DeviceHasJITFlags(JIT_FLAG_FORCE_MIRRORED)) {
+            // Non-TXM iOS 26+: avoid patching code in dsc, use hardware breakpoint instead
             NSDebugLog(@"[DyldLVBypass] Using redirectFunctionHWBreakpoint");
             redirectFunction = redirectFunctionHWBreakpoint;
-            break;
-        default:
+        } else {
             NSDebugLog(@"[DyldLVBypass] Using redirectFunctionDirect");
             redirectFunction = redirectFunctionDirect;
-            break;
+        }
+    } else {
+        NSDebugLog(@"[DyldLVBypass] Using redirectFunctionDirect");
+        redirectFunction = redirectFunctionDirect;
     }
     
     // Modifying exec page during execution may cause SIGBUS, so ignore it now


### PR DESCRIPTION
Fix black screen on iOS 26+ by adding Hardware Breakpoints and Mirrored Mapping as fallbacks to the dyld bypass.